### PR TITLE
Simplify hw interface

### DIFF
--- a/xarm_controller/include/xarm_controller/hardware/uf_robot_fake_system_hardware.h
+++ b/xarm_controller/include/xarm_controller/hardware/uf_robot_fake_system_hardware.h
@@ -46,7 +46,6 @@ namespace uf_robot_hardware
         hardware_interface::HardwareInfo info_;
     
     private:
-        std::vector<double> position_cmds_;
         std::vector<double> velocity_cmds_;
         std::vector<double> position_states_;
         std::vector<double> velocity_states_;

--- a/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
+++ b/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
@@ -74,30 +74,15 @@ namespace uf_robot_hardware
 
         long int read_cnts_;
         long int read_failed_cnts_;
-        double read_max_time_;
-        double read_total_time_;
         
-        float prev_read_position_[7];
 		float curr_read_position_[7];
 		float curr_read_velocity_[7];
 		float curr_read_effort_[7];
         
-        rclcpp::Time prev_read_time_;
-        rclcpp::Time curr_read_time_;
-        rclcpp::Time curr_write_time_;
-        rclcpp::Time prev_write_time_;
 
         std::shared_ptr<rclcpp::Node> node_;
         std::shared_ptr<rclcpp::Node> hw_node_;
         xarm_api::XArmDriver xarm_driver_;
-
-        std::shared_ptr<controller_manager_msgs::srv::ListControllers::Request> req_list_controller_;
-	    std::shared_ptr<controller_manager_msgs::srv::ListControllers::Response> res_list_controller_;
-        std::shared_ptr<controller_manager_msgs::srv::SwitchController::Request> req_switch_controller_;
-        std::shared_ptr<controller_manager_msgs::srv::SwitchController::Response> res_switch_controller_;
-
-        rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedPtr client_list_controller_;
-        rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr client_switch_controller_;
 
         bool _check_cmds_is_change(float *prev, float *cur, double threshold = 0.0001);
         bool _xarm_is_ready_read(void);

--- a/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
+++ b/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
@@ -68,7 +68,6 @@ namespace uf_robot_hardware
         std::vector<double> position_states_;
         std::vector<double> velocity_states_;
 
-        bool velocity_control_;
         bool initialized_;
         bool read_ready_;
 

--- a/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
+++ b/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
@@ -61,7 +61,6 @@ namespace uf_robot_hardware
 
         std::string robot_ip_;
 
-        std::vector<double> position_cmds_;
         std::vector<double> velocity_cmds_;
         std::vector<double> position_states_;
         std::vector<double> velocity_states_;
@@ -84,10 +83,6 @@ namespace uf_robot_hardware
         bool _need_reset(void);
 
         void _init_ufactory_driver(void);
-
-        template<typename ServiceT, typename SharedRequest = typename ServiceT::Request::SharedPtr, typename SharedResponse = typename ServiceT::Response::SharedPtr>
-        int _call_request(std::shared_ptr<ServiceT> client, SharedRequest req, SharedResponse& res);
-
     };
 }
 

--- a/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
+++ b/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
@@ -61,8 +61,6 @@ namespace uf_robot_hardware
 
         std::string robot_ip_;
 
-        float prev_cmds_float_[7];
-		float cmds_float_[7];
         std::vector<double> position_cmds_;
         std::vector<double> velocity_cmds_;
         std::vector<double> position_states_;
@@ -73,11 +71,6 @@ namespace uf_robot_hardware
 
         long int read_cnts_;
         long int read_failed_cnts_;
-        
-		float curr_read_position_[7];
-		float curr_read_velocity_[7];
-		float curr_read_effort_[7];
-        
 
         std::shared_ptr<rclcpp::Node> node_;
         std::shared_ptr<rclcpp::Node> hw_node_;

--- a/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
+++ b/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
@@ -71,7 +71,6 @@ namespace uf_robot_hardware
         bool velocity_control_;
         bool initialized_;
         bool read_ready_;
-        bool reload_controller_;
 
         long int read_cnts_;
         long int read_failed_cnts_;
@@ -106,8 +105,6 @@ namespace uf_robot_hardware
         bool _firmware_version_is_ge(int major, int minor, int revision);
 
         bool _need_reset(void);
-
-        void _reload_controller(void);
 
         void _init_ufactory_driver(void);
 

--- a/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
+++ b/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
@@ -75,7 +75,6 @@ namespace uf_robot_hardware
         std::shared_ptr<rclcpp::Node> hw_node_;
         xarm_api::XArmDriver xarm_driver_;
 
-        bool _check_cmds_is_change(float *prev, float *cur, double threshold = 0.0001);
         bool _xarm_is_ready_read(void);
         bool _xarm_is_ready_write(void);
         bool _firmware_version_is_ge(int major, int minor, int revision);

--- a/xarm_controller/src/hardware/uf_robot_fake_system_hardware.cpp
+++ b/xarm_controller/src/hardware/uf_robot_fake_system_hardware.cpp
@@ -40,31 +40,15 @@ namespace uf_robot_hardware
 
         position_states_.resize(info_.joints.size(), 0);
         velocity_states_.resize(info_.joints.size(), 0);
-        position_cmds_.resize(info_.joints.size(), 0);
         velocity_cmds_.resize(info_.joints.size(), 0);
 
         for (int i = 0; i < info_.joints.size(); i++) {
             joint_state_msg_.name[i] = info_.joints[i].name;
             position_states_[i] = std::stod( info_.joints[i].parameters["sim_init"]);
-            position_cmds_[i] = std::stod( info_.joints[i].parameters["sim_init"]);
         }
 
 
         for (const hardware_interface::ComponentInfo & joint : info_.joints) {
-            bool has_pos_cmd_interface = false;
-            for (auto i = 0u; i < joint.command_interfaces.size(); ++i) {
-                if (joint.command_interfaces[i].name == hardware_interface::HW_IF_POSITION) {
-                    has_pos_cmd_interface = true;
-                    break;
-                }
-            }
-            if (!has_pos_cmd_interface) {
-                RCLCPP_ERROR(LOGGER, "Joint '%s' has %ld command interfaces found, but not found %s command interface",
-                    joint.name.c_str(), joint.command_interfaces.size(), hardware_interface::HW_IF_POSITION
-                );
-                return CallbackReturn::ERROR;
-            }
-
             bool has_pos_state_interface = false;
             for (auto i = 0u; i < joint.state_interfaces.size(); ++i) {
                 if (joint.state_interfaces[i].name == hardware_interface::HW_IF_POSITION) {
@@ -101,8 +85,6 @@ namespace uf_robot_hardware
     {
         std::vector<hardware_interface::CommandInterface> command_interfaces;
         for (uint i = 0; i < info_.joints.size(); i++) {
-            command_interfaces.emplace_back(hardware_interface::CommandInterface(
-                info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_cmds_[i]));
             command_interfaces.emplace_back(hardware_interface::CommandInterface(
                 info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_cmds_[i]));
         }
@@ -143,21 +125,8 @@ namespace uf_robot_hardware
 
     hardware_interface::return_type UFRobotFakeSystemHardware::write(const rclcpp::Time & time, const rclcpp::Duration &period)
     {
-        // std::string pos_str = "[ ";
-        // std::string vel_str = "[ ";
-        // for (int i = 0; i < position_cmds_.size(); i++) { 
-        //     pos_str += std::to_string(position_cmds_[i]); 
-        //     pos_str += " ";
-        //     vel_str += std::to_string(velocity_cmds_[i]); 
-        //     vel_str += " ";
-        // }
-        // pos_str += "]";
-        // vel_str += "]";
-        // RCLCPP_INFO(LOGGER, "positon: %s, velocity: %s", pos_str.c_str(), vel_str.c_str());
-
-        for (int i = 0; i < position_cmds_.size(); i++) { 
-            position_states_[i] = position_cmds_[i];
-            joint_state_msg_.position[i] = position_cmds_[i];
+        for (int i = 0; i < position_states_.size(); i++) {
+            position_states_[i] *= velocity_cmds_[i] * period.seconds();
         }
         for (int i = 0; i < velocity_cmds_.size(); i++) { 
             velocity_states_[i] = velocity_cmds_[i];

--- a/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
+++ b/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
@@ -175,8 +175,6 @@ namespace uf_robot_hardware
 
         read_cnts_ = 0;
         read_failed_cnts_ = 0;
-        memset(cmds_float_, 0, sizeof(cmds_float_));
-        memset(prev_cmds_float_, 0, sizeof(prev_cmds_float_));
 
         _init_ufactory_driver();
         
@@ -251,23 +249,16 @@ namespace uf_robot_hardware
 		xarm_driver_.arm->set_mode(XARM_MODE::VELO_JOINT);
 		xarm_driver_.arm->set_state(XARM_STATE::START);
 
-
+        // This section is probably not needed. When we activate the hardware, we can only get reasonable values
+        // from the robot after doing the read() function.
         for (uint i = 0; i < position_states_.size(); i++) {
-            if (std::isnan(position_states_[i])) {
-                position_states_[i] = 0;
-                position_cmds_[i] = 0;
-            } else {
-                position_cmds_[i] = position_states_[i];
-            }
+            position_cmds_[i] = position_states_[i];
         }
         for (uint i = 0; i < velocity_states_.size(); i++) {
-            if (std::isnan(velocity_states_[i])) {
-                velocity_states_[i] = 0;
-                velocity_cmds_[i] = 0;
-            } else {
-                velocity_cmds_[i] = velocity_states_[i];
-            }
+            velocity_cmds_[i] = 0.0;
         }
+
+        initialized_ = false;
         
         RCLCPP_INFO(LOGGER, "[%s] System Sucessfully started!", robot_ip_.c_str());
         return CallbackReturn::SUCCESS;
@@ -293,13 +284,17 @@ namespace uf_robot_hardware
             RCLCPP_ERROR(LOGGER, "Robot firmware version is lower than 1.8.103, please update the firmware to use new API");
             return hardware_interface::return_type::ERROR;
         }
-		read_code_ = xarm_driver_.arm->get_joint_states(curr_read_position_, curr_read_velocity_, curr_read_effort_);
+		float curr_read_position[7];
+		float curr_read_velocity[7];
+		float curr_read_effort[7];
+
+		read_code_ = xarm_driver_.arm->get_joint_states(curr_read_position, curr_read_velocity, curr_read_effort);
         read_ready_ = read_ready_ && _xarm_is_ready_read();
 
         if (read_code_ == 0 && read_ready_) {
             for (int j = 0; j < info_.joints.size(); j++) {
-                position_states_[j] = curr_read_position_[j];
-				velocity_states_[j] = curr_read_velocity_[j];
+                position_states_[j] = curr_read_position[j];
+				velocity_states_[j] = curr_read_velocity[j];
 
             }
             if (!initialized_) {
@@ -334,19 +329,20 @@ namespace uf_robot_hardware
         }
         initialized_ = true;
         
+		float cmds_float[7];
         int cmd_ret = 0;
         for (int i = 0; i < velocity_cmds_.size(); i++) { 
             if (std::isnan(velocity_cmds_[i])) {
                 RCLCPP_ERROR(LOGGER, "[%s] velocity_cmds_[%d] is NaN", robot_ip_.c_str(), i);
                 return hardware_interface::return_type::ERROR;
             }
-            cmds_float_[i] = (float)velocity_cmds_[i];
+            cmds_float[i] = (float)velocity_cmds_[i];
         }
-        cmd_ret = xarm_driver_.arm->vc_set_joint_velocity(cmds_float_, true, VELO_DURATION);
+        cmd_ret = xarm_driver_.arm->vc_set_joint_velocity(cmds_float, true, VELO_DURATION);
         if (cmd_ret != 0) {
             std::stringstream vel_commands;
             for (int i = 0; i < 7; i++) {
-                vel_commands << cmds_float_[i] << " ";
+                vel_commands << cmds_float[i] << " ";
             }
             RCLCPP_WARN(LOGGER, "[%s] vc_set_joint_velocity, ret=%d, commands: %s", robot_ip_.c_str(), cmd_ret, vel_commands.str().c_str());
         }

--- a/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
+++ b/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
@@ -164,7 +164,6 @@ namespace uf_robot_hardware
         write_code_ = 0;
 
         initialized_ = false;
-        reload_controller_ = false;
 
         read_cnts_ = 0;
         read_max_time_ = 0;
@@ -324,15 +323,11 @@ namespace uf_robot_hardware
                     position_cmds_[i] = position_states_[i];
                     velocity_cmds_[i] = 0.0;
                 }
-                if (reload_controller_ && _check_cmds_is_change(curr_read_position_, prev_read_position_)) {
-                    _reload_controller();
-                }
             }
             memcpy(prev_read_position_, curr_read_position_, sizeof(float) * 7);
             prev_read_time_ = curr_read_time_;
         }
         else {
-            // initialized_ = read_ready_ && _xarm_is_ready_write();
             if (read_code_) {
                 read_failed_cnts_ += 1;
                 RCLCPP_INFO(LOGGER, "[%s] Read() returns: %d", robot_ip_.c_str(), read_code_);
@@ -352,7 +347,6 @@ namespace uf_robot_hardware
         if (_need_reset()) {
             RCLCPP_WARN_STREAM_THROTTLE(LOGGER, *get_clock(), 2000,
              "Robot arm is not in velocity control mode.");
-            if (initialized_) reload_controller_ = true;
             initialized_ = false;
             return hardware_interface::return_type::OK;
         }
@@ -379,23 +373,6 @@ namespace uf_robot_hardware
         }
 
         return hardware_interface::return_type::OK;
-    }
-
-    void UFRobotSystemHardware::_reload_controller(void) {
-        int ret = _call_request(client_list_controller_, req_list_controller_, res_list_controller_);
-        if (ret == 0 && res_list_controller_->controller.size() > 0) {
-            req_switch_controller_->activate_controllers.resize(res_list_controller_->controller.size());
-            req_switch_controller_->deactivate_controllers.resize(res_list_controller_->controller.size());
-            for (uint i = 0; i < res_list_controller_->controller.size(); i++) {
-                req_switch_controller_->activate_controllers[i] = res_list_controller_->controller[i].name;
-                req_switch_controller_->deactivate_controllers[i] = res_list_controller_->controller[i].name;
-            }
-            req_switch_controller_->strictness = controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT;
-            _call_request(client_switch_controller_, req_switch_controller_, res_switch_controller_);
-        }
-        if (ret == 0) {
-            reload_controller_ = false;
-        }
     }
 
     bool UFRobotSystemHardware::_check_cmds_is_change(float *prev, float *cur, double threshold)

--- a/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
+++ b/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
@@ -18,33 +18,6 @@ namespace uf_robot_hardware
 {
     static rclcpp::Logger LOGGER = rclcpp::get_logger("UFACTORY.RobotHW");
 
-    template<typename ServiceT, typename SharedRequest, typename SharedResponse>
-    int UFRobotSystemHardware::_call_request(std::shared_ptr<ServiceT> client, SharedRequest req, SharedResponse& res)
-    {
-        bool is_try_again = false;
-        int failed_cnts = 0;
-        while (!client->wait_for_service(std::chrono::seconds(1))) {
-            if (!rclcpp::ok()) {
-                RCLCPP_ERROR(LOGGER, "[%s] Interrupted while waiting for the service. Exiting.", robot_ip_.c_str());
-                exit(1);
-            }
-            if (!is_try_again) {
-                is_try_again = true;
-                RCLCPP_WARN(LOGGER, "[%s] service %s not available, waiting ...", robot_ip_.c_str(), client->get_service_name());
-            }
-            failed_cnts += 1;
-            if (failed_cnts >= 5) return WAIT_SERVICE_TIMEOUT;
-        }
-        auto result_future = client->async_send_request(req);
-        if (rclcpp::spin_until_future_complete(hw_node_, result_future, std::chrono::seconds(1)) != rclcpp::FutureReturnCode::SUCCESS)
-        {
-            // RCLCPP_ERROR(LOGGER, "[%s] Failed to call service %s", robot_ip_.c_str(), client->get_service_name());
-            return SERVICE_CALL_FAILED;
-        }
-        res = result_future.get();
-        return 0;
-    }
-
     void UFRobotSystemHardware::_init_ufactory_driver(void)
     {
         rclcpp::NodeOptions node_options;
@@ -180,24 +153,9 @@ namespace uf_robot_hardware
         
         position_states_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
         velocity_states_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
-        position_cmds_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
         velocity_cmds_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
 
         for (const hardware_interface::ComponentInfo & joint : info_.joints) {
-            bool has_pos_cmd_interface = false;
-            for (auto i = 0u; i < joint.command_interfaces.size(); ++i) {
-                if (joint.command_interfaces[i].name == hardware_interface::HW_IF_POSITION) {
-                    has_pos_cmd_interface = true;
-                    break;
-                }
-            }
-            if (!has_pos_cmd_interface) {
-                RCLCPP_ERROR(LOGGER, "[%s] Joint '%s' has %ld command interfaces found, but not found %s command interface",
-                    robot_ip_.c_str(), joint.name.c_str(), joint.command_interfaces.size(), hardware_interface::HW_IF_POSITION
-                );
-                return CallbackReturn::ERROR;
-            }
-
             bool has_pos_state_interface = false;
             for (auto i = 0u; i < joint.state_interfaces.size(); ++i) {
                 if (joint.state_interfaces[i].name == hardware_interface::HW_IF_POSITION) {
@@ -235,8 +193,6 @@ namespace uf_robot_hardware
         std::vector<hardware_interface::CommandInterface> command_interfaces;
         for (uint i = 0; i < info_.joints.size(); i++) {
             command_interfaces.emplace_back(hardware_interface::CommandInterface(
-                info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_cmds_[i]));
-            command_interfaces.emplace_back(hardware_interface::CommandInterface(
                 info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_cmds_[i]));
         }
 
@@ -251,9 +207,6 @@ namespace uf_robot_hardware
 
         // This section is probably not needed. When we activate the hardware, we can only get reasonable values
         // from the robot after doing the read() function.
-        for (uint i = 0; i < position_states_.size(); i++) {
-            position_cmds_[i] = position_states_[i];
-        }
         for (uint i = 0; i < velocity_states_.size(); i++) {
             velocity_cmds_[i] = 0.0;
         }
@@ -299,7 +252,6 @@ namespace uf_robot_hardware
             }
             if (!initialized_) {
                 for (uint i = 0; i < position_states_.size(); i++) {
-                    position_cmds_[i] = position_states_[i];
                     velocity_cmds_[i] = 0.0;
                 }
             }

--- a/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
+++ b/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
@@ -358,18 +358,6 @@ namespace uf_robot_hardware
         }
         initialized_ = true;
         
-        // std::string pos_str = "[ ";
-        // std::string vel_str = "[ ";
-        // for (int i = 0; i < position_cmds_.size(); i++) { 
-        //     pos_str += std::to_string(position_cmds_[i]); 
-        //     pos_str += " ";
-        //     vel_str += std::to_string(velocity_cmds_[i]); 
-        //     vel_str += " ";
-        // }
-        // pos_str += "]";
-        // vel_str += "]";
-        // RCLCPP_INFO(LOGGER, "[%s] positon: %s, velocity: %s", robot_ip_.c_str(), pos_str.c_str(), vel_str.c_str());
-
         int cmd_ret = 0;
         if (velocity_control_) {
             for (int i = 0; i < velocity_cmds_.size(); i++) { 
@@ -387,28 +375,6 @@ namespace uf_robot_hardware
                     vel_commands << cmds_float_[i] << " ";
                 }
                 RCLCPP_WARN(LOGGER, "[%s] vc_set_joint_velocity, ret=%d, commands: %s", robot_ip_.c_str(), cmd_ret, vel_commands.str().c_str());
-            }
-        }
-        else {
-            RCLCPP_ERROR(LOGGER, "We should never be in position control mode. Something must have gone wrong");
-            return hardware_interface::return_type::ERROR;
-
-            for (int i = 0; i < position_cmds_.size(); i++) { 
-                cmds_float_[i] = (float)position_cmds_[i];
-            }
-            curr_write_time_ = node_->get_clock()->now();
-            if (curr_write_time_.seconds() - prev_write_time_.seconds() > 1 || _check_cmds_is_change(prev_cmds_float_, cmds_float_)) {
-                // RCLCPP_INFO(LOGGER, "[%s] positon: %s", robot_ip_.c_str(), pos_str.c_str());
-                cmd_ret = xarm_driver_.arm->set_servo_angle_j(cmds_float_, 0, 0, 0);
-                if (cmd_ret != 0) {
-                    RCLCPP_WARN(LOGGER, "[%s] set_servo_angle_j, ret= %d", robot_ip_.c_str(), cmd_ret);
-                }
-                if (cmd_ret == 0) {
-                    prev_write_time_ = curr_write_time_;
-                    for (int i = 0; i < 7; i++) { 
-                        prev_cmds_float_[i] = (float)cmds_float_[i];
-                    }
-                }
             }
         }
 

--- a/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
+++ b/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
@@ -302,14 +302,6 @@ namespace uf_robot_hardware
         return hardware_interface::return_type::OK;
     }
 
-    bool UFRobotSystemHardware::_check_cmds_is_change(float *prev, float *cur, double threshold)
-	{
-		for (int i = 0; i < 7; i++) {
-            if (std::abs(cur[i] - prev[i]) > threshold) return true;
-        }
-        return false;
-	}
-
     bool UFRobotSystemHardware::_xarm_is_ready_read(void)
     {
         static int last_err = xarm_driver_.curr_err;

--- a/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
+++ b/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
@@ -166,8 +166,6 @@ namespace uf_robot_hardware
         initialized_ = false;
 
         read_cnts_ = 0;
-        read_max_time_ = 0;
-        read_total_time_ = 0;
         read_failed_cnts_ = 0;
         memset(cmds_float_, 0, sizeof(cmds_float_));
         memset(prev_cmds_float_, 0, sizeof(prev_cmds_float_));
@@ -245,13 +243,6 @@ namespace uf_robot_hardware
 		xarm_driver_.arm->set_mode(velocity_control_ ? XARM_MODE::VELO_JOINT : XARM_MODE::SERVO);
 		xarm_driver_.arm->set_state(XARM_STATE::START);
 
-        req_list_controller_ = std::make_shared<controller_manager_msgs::srv::ListControllers::Request>();
-        res_list_controller_ = std::make_shared<controller_manager_msgs::srv::ListControllers::Response>();
-        req_switch_controller_ = std::make_shared<controller_manager_msgs::srv::SwitchController::Request>();
-        res_switch_controller_ = std::make_shared<controller_manager_msgs::srv::SwitchController::Response>();
-
-        client_list_controller_ = hw_node_->create_client<controller_manager_msgs::srv::ListControllers>("/controller_manager/list_controllers");
-        client_switch_controller_ = hw_node_->create_client<controller_manager_msgs::srv::SwitchController>("/controller_manager/switch_controller");
 
         for (uint i = 0; i < position_states_.size(); i++) {
             if (std::isnan(position_states_[i])) {
@@ -288,35 +279,20 @@ namespace uf_robot_hardware
     {
         read_cnts_ += 1;
         read_ready_ = _xarm_is_ready_read();
-        rclcpp::Time start = node_->get_clock()->now();
 
         bool use_new = _firmware_version_is_ge(1, 8, 103);
-        if (use_new)
-			read_code_ = xarm_driver_.arm->get_joint_states(curr_read_position_, curr_read_velocity_, curr_read_effort_);
-		else
-			read_code_ = xarm_driver_.arm->get_servo_angle(curr_read_position_);
-        
-        curr_read_time_ = node_->get_clock()->now();
-        read_ready_ = read_ready_ && _xarm_is_ready_read();
-        double time_sec = curr_read_time_.seconds() - start.seconds();
-        read_total_time_ += time_sec;
-        if (time_sec > read_max_time_) {
-            read_max_time_ = time_sec;
+        if (!use_new){
+            RCLCPP_ERROR(LOGGER, "Robot firmware version is lower than 1.8.103, please update the firmware to use new API");
+            return hardware_interface::return_type::ERROR;
         }
-        // if (read_cnts_ % 6000 == 0) {
-        //     RCLCPP_INFO(LOGGER, "[%s] [READ] cnt: %ld, max: %f, mean: %f, failed: %ld", robot_ip_.c_str(), read_cnts_, read_max_time_, read_total_time_ / read_cnts_, read_failed_cnts_);
-        // }
+		read_code_ = xarm_driver_.arm->get_joint_states(curr_read_position_, curr_read_velocity_, curr_read_effort_);
+        read_ready_ = read_ready_ && _xarm_is_ready_read();
+
         if (read_code_ == 0 && read_ready_) {
             for (int j = 0; j < info_.joints.size(); j++) {
                 position_states_[j] = curr_read_position_[j];
-				if (use_new) {
-					velocity_states_[j] = curr_read_velocity_[j];
-					// effort_states_[j] = curr_read_effort_[j];
-				}
-				else {
-					velocity_states_[j] = !initialized_ ? 0.0 : (curr_read_position_[j] - prev_read_position_[j]) / (curr_read_time_.seconds() - prev_read_time_.seconds());
-					// effort_states_[j] = 0.0;
-				}
+				velocity_states_[j] = curr_read_velocity_[j];
+
             }
             if (!initialized_) {
                 for (uint i = 0; i < position_states_.size(); i++) {
@@ -324,8 +300,6 @@ namespace uf_robot_hardware
                     velocity_cmds_[i] = 0.0;
                 }
             }
-            memcpy(prev_read_position_, curr_read_position_, sizeof(float) * 7);
-            prev_read_time_ = curr_read_time_;
         }
         else {
             if (read_code_) {
@@ -361,7 +335,6 @@ namespace uf_robot_hardware
                 }
                 cmds_float_[i] = (float)velocity_cmds_[i];
             }
-            // RCLCPP_INFO(LOGGER, "[%s] velocity: %s", robot_ip_.c_str(), vel_str.c_str());
             cmd_ret = xarm_driver_.arm->vc_set_joint_velocity(cmds_float_, true, VELO_DURATION);
             if (cmd_ret != 0) {
                 std::stringstream vel_commands;

--- a/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
+++ b/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
@@ -143,12 +143,21 @@ namespace uf_robot_hardware
         if (robot_type == "lite") add_bio_gripper = false;
         node_->set_parameter(rclcpp::Parameter("add_bio_gripper", add_bio_gripper));
 
+        bool velocity_control_set = false;
         it = info_.hardware_parameters.find("velocity_control");
         if (it != info_.hardware_parameters.end()) {
-            velocity_control_ = (it->second == "True" || it->second == "true");
+            velocity_control_set = (it->second == "True" || it->second == "true");
         }
-        RCLCPP_INFO(LOGGER, "[%s] dof: %d, velocity_control: %d, add_gripper: %d, add_bio_gripper: %d, baud_checkset: %d, default_gripper_baud: %d", 
-            robot_ip_.c_str(), dof, velocity_control_, add_gripper, add_bio_gripper, baud_checkset, default_gripper_baud);
+        else{
+            velocity_control_set = false; // parameter not set
+        }
+        if (!velocity_control_set) {
+            RCLCPP_ERROR(LOGGER, "velocity_control is not set in config file. We currently only support velocity_control mode.");
+            exit(1);
+        }
+
+        RCLCPP_INFO(LOGGER, "[%s] dof: %d, velocity_control_set: %d, add_gripper: %d, add_bio_gripper: %d, baud_checkset: %d, default_gripper_baud: %d", 
+            robot_ip_.c_str(), dof, velocity_control_set, add_gripper, add_bio_gripper, baud_checkset, default_gripper_baud);
         
         xarm_driver_.init(node_, robot_ip_);
     }
@@ -159,7 +168,6 @@ namespace uf_robot_hardware
             return CallbackReturn::ERROR;
         }
         info_ = info;
-        velocity_control_ = false;
         read_code_ = 0;
         write_code_ = 0;
 
@@ -240,7 +248,7 @@ namespace uf_robot_hardware
     CallbackReturn UFRobotSystemHardware::on_activate(const rclcpp_lifecycle::State& previous_state)
     {
         xarm_driver_.arm->motion_enable(true);
-		xarm_driver_.arm->set_mode(velocity_control_ ? XARM_MODE::VELO_JOINT : XARM_MODE::SERVO);
+		xarm_driver_.arm->set_mode(XARM_MODE::VELO_JOINT);
 		xarm_driver_.arm->set_state(XARM_STATE::START);
 
 
@@ -327,22 +335,20 @@ namespace uf_robot_hardware
         initialized_ = true;
         
         int cmd_ret = 0;
-        if (velocity_control_) {
-            for (int i = 0; i < velocity_cmds_.size(); i++) { 
-                if (std::isnan(velocity_cmds_[i])) {
-                    RCLCPP_ERROR(LOGGER, "[%s] velocity_cmds_[%d] is NaN", robot_ip_.c_str(), i);
-                    return hardware_interface::return_type::ERROR;
-                }
-                cmds_float_[i] = (float)velocity_cmds_[i];
+        for (int i = 0; i < velocity_cmds_.size(); i++) { 
+            if (std::isnan(velocity_cmds_[i])) {
+                RCLCPP_ERROR(LOGGER, "[%s] velocity_cmds_[%d] is NaN", robot_ip_.c_str(), i);
+                return hardware_interface::return_type::ERROR;
             }
-            cmd_ret = xarm_driver_.arm->vc_set_joint_velocity(cmds_float_, true, VELO_DURATION);
-            if (cmd_ret != 0) {
-                std::stringstream vel_commands;
-                for (int i = 0; i < 7; i++) {
-                    vel_commands << cmds_float_[i] << " ";
-                }
-                RCLCPP_WARN(LOGGER, "[%s] vc_set_joint_velocity, ret=%d, commands: %s", robot_ip_.c_str(), cmd_ret, vel_commands.str().c_str());
+            cmds_float_[i] = (float)velocity_cmds_[i];
+        }
+        cmd_ret = xarm_driver_.arm->vc_set_joint_velocity(cmds_float_, true, VELO_DURATION);
+        if (cmd_ret != 0) {
+            std::stringstream vel_commands;
+            for (int i = 0; i < 7; i++) {
+                vel_commands << cmds_float_[i] << " ";
             }
+            RCLCPP_WARN(LOGGER, "[%s] vc_set_joint_velocity, ret=%d, commands: %s", robot_ip_.c_str(), cmd_ret, vel_commands.str().c_str());
         }
 
         return hardware_interface::return_type::OK;
@@ -392,7 +398,7 @@ namespace uf_robot_hardware
         }
         last_state = curr_state;
 
-        if (!(velocity_control_ ? curr_mode == XARM_MODE::VELO_JOINT : curr_mode == XARM_MODE::SERVO)) {
+        if (curr_mode != XARM_MODE::VELO_JOINT) {
             if (last_mode != curr_mode) {
                 last_mode = curr_mode;
                 RCLCPP_WARN(LOGGER, "[%s] Robot Mode detected! Mode: %d", robot_ip_.c_str(), curr_mode);

--- a/xarm_description/urdf/uf850/uf850.ros2_control.xacro
+++ b/xarm_description/urdf/uf850/uf850.ros2_control.xacro
@@ -37,10 +37,6 @@
         <!-- <plugin>uf_robot_hardware/UFRobotSystemHardware</plugin> -->
       </hardware>
       <joint name="${prefix}joint1">
-        <command_interface name="position">
-          <param name="min">${joint1_lower_limit}</param>
-          <param name="max">${joint1_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
@@ -51,10 +47,6 @@
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint2">
-        <command_interface name="position">
-          <param name="min">${joint2_lower_limit}</param>
-          <param name="max">${joint2_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
@@ -65,10 +57,6 @@
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint3">
-        <command_interface name="position">
-          <param name="min">${joint3_lower_limit}</param>
-          <param name="max">${joint3_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
@@ -79,10 +67,6 @@
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint4">
-        <command_interface name="position">
-          <param name="min">${joint4_lower_limit}</param>
-          <param name="max">${joint4_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
@@ -93,10 +77,6 @@
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint5">
-        <command_interface name="position">
-          <param name="min">${joint5_lower_limit}</param>
-          <param name="max">${joint5_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
@@ -107,10 +87,6 @@
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint6">
-        <command_interface name="position">
-          <param name="min">${joint6_lower_limit}</param>
-          <param name="max">${joint6_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>

--- a/xarm_description/urdf/xarm6/xarm6.ros2_control.xacro
+++ b/xarm_description/urdf/xarm6/xarm6.ros2_control.xacro
@@ -37,10 +37,6 @@
         <!-- <plugin>uf_robot_hardware/UFRobotSystemHardware</plugin> -->
       </hardware>
       <joint name="${prefix}joint1">
-        <command_interface name="position">
-          <param name="min">${joint1_lower_limit}</param>
-          <param name="max">${joint1_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
@@ -51,10 +47,6 @@
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint2">
-        <command_interface name="position">
-          <param name="min">${joint2_lower_limit}</param>
-          <param name="max">${joint2_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
@@ -65,10 +57,6 @@
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint3">
-        <command_interface name="position">
-          <param name="min">${joint3_lower_limit}</param>
-          <param name="max">${joint3_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
@@ -79,10 +67,6 @@
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint4">
-        <command_interface name="position">
-          <param name="min">${joint4_lower_limit}</param>
-          <param name="max">${joint4_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
@@ -93,10 +77,6 @@
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint5">
-        <command_interface name="position">
-          <param name="min">${joint5_lower_limit}</param>
-          <param name="max">${joint5_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
@@ -107,10 +87,6 @@
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint6">
-        <command_interface name="position">
-          <param name="min">${joint6_lower_limit}</param>
-          <param name="max">${joint6_upper_limit}</param>
-        </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>


### PR DESCRIPTION
Delete a lot of unused code from the hardware interface.

Especially the previous on_activation routine looked suspicious. We were setting position readings to zero there.

Also removed some controller switching logic that was triggered when the robot state was changed and there was an offset in the position readings which also could have been a source of errors.